### PR TITLE
[update] update Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     multi_json (1.12.1)
     multipart-post (2.0.0)
     mustermann (1.0.1)
-    nokogiri (1.8.0)
+    nokogiri (1.8.1)
       mini_portile2 (~> 2.2.0)
     rack (2.0.3)
     rack-protection (2.0.0)


### PR DESCRIPTION
changed Nokogori's version from 1.8.0 to 1.8.1 because 1.8.0 is deprecated